### PR TITLE
Prepend anchor inside target element, instead of inserting outside.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-element-spy",
   "description": "Vue.js plugin for detecting when element reaches top of the viewport. The plugin uses Intersection Observer.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "scripts": {
     "build": "rollup -c rollup.config.js"
   },

--- a/src/vue-element-spy.js
+++ b/src/vue-element-spy.js
@@ -37,7 +37,7 @@ function setup(el, config) {
   const anchor = document.createElement('div');
   anchor.style.cssText = 'width: 0; height: 0; display: block;';
   anchor.className = 'vue-element-spy-anchor';
-  el.parentElement.insertBefore(anchor, el);
+  el.prepend(anchor);
   target.anchor = anchor;
 
   topObserver.observe(anchor);


### PR DESCRIPTION
This allows the spied-upon element to prevent the `display: block` anchor from messing up the layout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/vue-element-spy/7)
<!-- Reviewable:end -->
